### PR TITLE
User created resources

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [ring-server "0.3.1"]
                  [amazonica "0.3.18"]
                  [environ "1.0.0"]
-                 [spurious-aws-sdk-helper "0.1.0"]]
+                 [spurious-aws-sdk-helper "0.2.0"]]
   :plugins [[lein-ring "0.8.12"]
             [lein-environ "1.0.0"]]
   :main ^:skip-aot spurious-clojure-example.repl

--- a/src/spurious_clojure_example/handler.clj
+++ b/src/spurious_clojure_example/handler.clj
@@ -5,7 +5,8 @@
             [hiccup.middleware :refer [wrap-base-url]]
             [compojure.handler :as handler]
             [compojure.route :as route]
-            [spurious-clojure-example.routes.home :refer [home-routes]]))
+            [spurious-clojure-example.routes.home :refer [home-routes]]
+            [spurious-clojure-example.routes.custom :refer [custom-routes]]))
 
 (defn init []
   (println "spurious-clojure-example is starting"))
@@ -18,6 +19,6 @@
   (route/not-found "Not Found"))
 
 (def app
-  (-> (routes home-routes app-routes)
+  (-> (routes home-routes custom-routes app-routes)
       (handler/site)
       (wrap-base-url)))

--- a/src/spurious_clojure_example/routes/custom.clj
+++ b/src/spurious_clojure_example/routes/custom.clj
@@ -1,0 +1,31 @@
+(ns spurious-clojure-example.routes.custom
+  (:use [amazonica.aws.s3])
+  (:require [compojure.core :refer :all]
+            [environ.core :refer [env]]
+            [spurious-aws-sdk-helper.core :as core]
+            [spurious-aws-sdk-helper.utils :refer [endpoint cred]]
+            [spurious-clojure-example.views.layout :as layout]))
+
+(when (env :debug)
+  (core/configure :app))
+
+(defn credentials []
+  (if (env :debug)
+    (cred (endpoint :app :spurious-s3))
+    {:access-key "foo"
+     :secret-key "bar"}))
+
+(defn content [bucket object]
+  (apply str (line-seq
+               (clojure.java.io/reader
+                 (:object-content
+                   (get-object (credentials) :bucket-name bucket :key object))))))
+
+(def cache-content (memoize content))
+
+(defn custom []
+  (create-bucket (credentials) "made-up-bucket")
+  (layout/common (str "<div style='background:yellow'>" (cache-content "foo-bucket" "bar/baz/header") "</div>")))
+
+(defroutes custom-routes
+  (GET "/custom" [] (custom)))


### PR DESCRIPTION
![getinsertpic.com](http://media0.giphy.com/media/cx0uBMDkwIEHm/200.gif)
## Problem

As pointed out by @jakechampion: the helper forced consumers to construct resources by passing a map data structure into the `core/configure` function.
## Solution

Create a multi-arity function within the helper that calls only the essential parts of the helper that enables the Spurious services to work with the AWS SDK.

[See the PR for the helper](https://github.com/Integralist/spurious-clojure-aws-sdk-helper/pull/2) that implements this change.

This PR simply adds a new route that demonstrates that the helper indeed works as documented in the updated README (it also shows that although a map of resources weren't provided to `core/configure`, the `/custom` route handler can still create a new resource - in this case an S3 bucket).
